### PR TITLE
Show timer in page title

### DIFF
--- a/client/src/components/Timer/Timer.tsx
+++ b/client/src/components/Timer/Timer.tsx
@@ -120,12 +120,13 @@ export const Timer = () => {
   // Show timer in page title when timer is running
   useEffect(() => {
     if (hasStarted) {
+      const icon = sessionType === "Session" ? "⏱" : "☕️";
       // @ts-ignore
-      document.title = `Astrostation ⏱${formatDisplayTime(timerMinutes)}:${formatDisplayTime(timerSeconds)}`;
+      document.title = `Astrostation ${icon}${formatDisplayTime(timerMinutes)}:${formatDisplayTime(timerSeconds)}`;
     } else {
       document.title = "Astrostation";
     }
-  }, [hasStarted, timerMinutes, timerSeconds]);
+  }, [hasStarted, timerMinutes, timerSeconds, sessionType]);
 
   function toggleCountDown() {
     if (hasStarted) {


### PR DESCRIPTION
![CleanShot 2022-06-13 at 23 46 55](https://user-images.githubusercontent.com/1153991/173502459-3735cc5e-295b-4f21-b00c-53d271f55489.gif)

Shows timer in browser title. Useful when you want to check how much time you have left on your pomodoro session or break.

### Notes/thoughts/improvements
- Unsure on how the emoji looks on Windows. Need to test.
- Could use different emojis for pomodoro sesh vs. break.
- Maybe want to consider putting the timer in front of "Astrostation" for when a ton of open tabs make the tab title condensed and the timer unreadable.

