### PR TITLE
"Stop" -> "Pause" on timer button to reduce confusion

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
 - royanger
 - nchudleigh
 - emalineg
+- Samathingamajig

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -236,7 +236,7 @@ export const Timer = () => {
               onClick={() => toggleCountDown()}
               variant="cold"
             >
-              <p className="tabular-nums">{hasStarted ? "Stop" : "Start"}</p>
+              <p className="tabular-nums">{hasStarted ? "Pause" : "Start"}</p>
             </Button>
             <Button
               className="ml-4 font-normal tabular-nums text-gray-800 hover:text-white dark:text-white"


### PR DESCRIPTION
Generally, countdown timers say "pause" to let the user know that it can be resumed later, as "stop" is generally a final action.

Ideally, there would be some kind of state to track "Start" -\> "Pause" \<-\> "Resume", but I didn't want add complexity. If others think this would be good, it's only adding a boolean `useState` and slightly complicating the displaying section with nested ternary.