### PR TITLE
BUGFIX: Task tracking

### DIFF
--- a/src/components/TaskTracker/Task.tsx
+++ b/src/components/TaskTracker/Task.tsx
@@ -66,8 +66,6 @@ export const Task = ({ task, tasks }) => {
   };
 
   const markNotCompleteWhenTracking = () => {
-    if (!task.inProgress) toggleInProgressState(task.id);
-
     toggleMenu(task.id, false);
     if (task.completed) setCompleted(task.id, false);
   };
@@ -146,7 +144,11 @@ export const Task = ({ task, tasks }) => {
                 }}
                 className="cursor-pointer rounded-md px-5 py-2 hover:bg-neutral-600"
               >
-                <div className="select-none ">Track Task</div>
+                { task.inProgress ? (
+                  <div className="select-none ">Untrack Task</div>
+                ) : (
+                  <div className="select-none ">Track Task</div>
+                )}
               </li>
               <li
                 onClick={() => {

--- a/src/components/TaskTracker/Task.tsx
+++ b/src/components/TaskTracker/Task.tsx
@@ -23,6 +23,7 @@ const onClickOff = callback => {
     document.addEventListener("click", handleClick);
     return () => document.removeEventListener("click", handleClick);
     function handleClick(e) {
+      // @ts-ignore
       if (innerRef.current && callbackRef.current && !innerRef.current.contains(e.target)) callbackRef.current(e);
     }
   }, []);

--- a/src/components/TaskTracker/Task.tsx
+++ b/src/components/TaskTracker/Task.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useState, RefCallback } from "react";
 import { FaCheck } from "react-icons/fa";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { BsThreeDotsVertical } from "react-icons/bs";
@@ -11,8 +11,8 @@ import { ITask } from "@Root/src/interfaces";
 // TODO: Add a blurb/instructions to let users know how to toggle
 
 const onClickOff = callback => {
-  const callbackRef = useRef(); // initialize mutable ref, which stores callback
-  const innerRef = useRef(); // returned to client, who marks "border" element
+  const callbackRef = useRef<RefCallback<null>>(); // initialize mutable ref, which stores callback
+  const innerRef = useRef<HTMLDivElement>(); // returned to client, who marks "border" element
 
   // update cb on each render, so second useEffect has access to current value
   useEffect(() => {
@@ -23,8 +23,9 @@ const onClickOff = callback => {
     document.addEventListener("click", handleClick);
     return () => document.removeEventListener("click", handleClick);
     function handleClick(e) {
-      // @ts-ignore
-      if (innerRef.current && callbackRef.current && !innerRef.current.contains(e.target)) callbackRef.current(e);
+      if (innerRef.current && callbackRef.current && !innerRef.current.contains(e.target)) {
+        callbackRef.current(e);
+      }
     }
   }, []);
 
@@ -63,10 +64,11 @@ export const Task = ({ task, tasks }) => {
     if (task.completed) {
       return;
     }
-    toggleInProgressState(task.id);
+    toggleInProgressState(task.id, !task.inProgress);
   };
 
   const markNotCompleteWhenTracking = () => {
+    toggleInProgressState(task.id, !task.inProgress);
     toggleMenu(task.id, false);
     if (task.completed) setCompleted(task.id, false);
   };
@@ -145,7 +147,7 @@ export const Task = ({ task, tasks }) => {
                 }}
                 className="cursor-pointer rounded-md px-5 py-2 hover:bg-neutral-600"
               >
-                { task.inProgress ? (
+                {task.inProgress ? (
                   <div className="select-none ">Untrack Task</div>
                 ) : (
                   <div className="select-none ">Track Task</div>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -104,7 +104,7 @@ export interface ITaskState {
   renameTask: (id: number, newName: string) => void;
   removeTask: (id: number) => void;
   removeAllTasks: () => void;
-  toggleInProgressState: (id: number) => void;
+  toggleInProgressState: (id: number, flag: boolean) => void;
   setCompleted: (id: number, flag: boolean) => void;
   setPomodoroCounter: (id: number) => void;
   alertTask: (id: number, flag: boolean) => void;

--- a/src/store.ts
+++ b/src/store.ts
@@ -339,10 +339,10 @@ export const useTask = create<ITaskState>(
         }));
       },
       removeAllTasks: () => set({ tasks: [] }),
-      toggleInProgressState: id => {
+      toggleInProgressState: (id, flag) => {
         set(state => ({
           tasks: state.tasks.map(task =>
-            task.id === id ? ({ ...task, inProgress: !task.inProgress } as ITask) : task
+            task.id === id ? ({ ...task, inProgress: flag } as ITask) : task
           ),
         }));
       },


### PR DESCRIPTION
By tracking a task, you could no longer not track it without resorting to a double-click. 

Untrack is now in place for a task that is already being tracked. 