### PR TITLE
(WIP) Issue 246 - Updating Delete Modal for Tasks

### DIFF
--- a/src/components/TaskTracker/DeleteModal.tsx
+++ b/src/components/TaskTracker/DeleteModal.tsx
@@ -1,4 +1,6 @@
-export const DeleteModal = () => {
+export const DeleteModal = ({ show, onCancel, onConfirm }) => {
+  //Toggle modal visibility
+
   return (
     <div className="modal">
       <div className="max-w-xs rounded-lg bg-white p-2 px-1 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
@@ -6,8 +8,12 @@ export const DeleteModal = () => {
           <div className="rounded pb-2 text-center font-bold">Are you sure you want to delete this task?</div>
           <hr className="border-t-3 mx-auto w-1/4 border-[#5c5c5c]" />
           <div className=" mt-3 flex justify-center">
-            <button className="mx-2 rounded bg-red-500 px-1 py-1 text-white ">Delete</button>
-            <button className="mx-2 rounded bg-gray-300 px-1 py-1 text-black ">Cancel</button>
+            <button onClick={onConfirm} className="mx-2 rounded bg-red-500 px-1 py-1 text-white ">
+              Delete
+            </button>
+            <button onClick={onCancel} className="mx-2 rounded bg-gray-300 px-1 py-1 text-black ">
+              Cancel
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/TaskTracker/DeleteModal.tsx
+++ b/src/components/TaskTracker/DeleteModal.tsx
@@ -5,9 +5,9 @@ export const DeleteModal = () => {
         <div className="border-gray-100 pb-2">
           <div className="rounded pb-2 text-center font-bold">Are you sure you want to delete this task?</div>
           <hr className="border-t-3 mx-auto w-1/4 border-[#5c5c5c]" />
-          <div className="my-3 flex justify-end gap-2">
-            <button className="rounded bg-red-500 px-1 py-1 text-white">Delete</button>
-            <button className="rounded bg-gray-300 px-1 py-1 text-black">Cancel</button>
+          <div className=" mt-3 flex justify-center">
+            <button className="mx-2 rounded bg-red-500 px-1 py-1 text-white ">Delete</button>
+            <button className="mx-2 rounded bg-gray-300 px-1 py-1 text-black ">Cancel</button>
           </div>
         </div>
       </div>

--- a/src/components/TaskTracker/DeleteModal.tsx
+++ b/src/components/TaskTracker/DeleteModal.tsx
@@ -3,7 +3,9 @@ export const DeleteModal = ({ task, show, onCancel, onConfirm }) => {
     <div className="modal">
       <div className="max-w-xs rounded-lg bg-white p-2 px-1 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
         <div className="border-gray-100 pb-2">
-          <div className="rounded pb-2 text-center font-bold">Are you sure you want to delete {task.description}?</div>
+          <div className="rounded pb-2 text-center font-bold">
+            Are you sure you want to delete "{task.description}"?
+          </div>
           <hr className="border-t-3 mx-auto w-1/4 border-[#5c5c5c]" />
           <div className=" mt-3 flex justify-center">
             <button onClick={onConfirm} className="mx-2 rounded bg-red-500 px-1 py-1 text-white ">

--- a/src/components/TaskTracker/DeleteModal.tsx
+++ b/src/components/TaskTracker/DeleteModal.tsx
@@ -1,0 +1,16 @@
+export const DeleteModal = () => {
+  return (
+    <div className="modal">
+      <div className="max-w-xs rounded-lg bg-white p-2 px-1 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+        <div className="border-gray-100 pb-2">
+          <div className="rounded pb-2 text-center font-bold">Are you sure you want to delete this task?</div>
+          <hr className="border-t-3 mx-auto w-1/4 border-[#5c5c5c]" />
+          <div className="my-3 flex justify-end gap-2">
+            <button className="rounded bg-red-500 px-1 py-1 text-white">Delete</button>
+            <button className="rounded bg-gray-300 px-1 py-1 text-black">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TaskTracker/DeleteModal.tsx
+++ b/src/components/TaskTracker/DeleteModal.tsx
@@ -1,9 +1,9 @@
-export const DeleteModal = ({ show, onCancel, onConfirm }) => {
+export const DeleteModal = ({ task, show, onCancel, onConfirm }) => {
   return (
     <div className="modal">
       <div className="max-w-xs rounded-lg bg-white p-2 px-1 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
         <div className="border-gray-100 pb-2">
-          <div className="rounded pb-2 text-center font-bold">Are you sure you want to delete this task?</div>
+          <div className="rounded pb-2 text-center font-bold">Are you sure you want to delete {task.description}?</div>
           <hr className="border-t-3 mx-auto w-1/4 border-[#5c5c5c]" />
           <div className=" mt-3 flex justify-center">
             <button onClick={onConfirm} className="mx-2 rounded bg-red-500 px-1 py-1 text-white ">

--- a/src/components/TaskTracker/DeleteModal.tsx
+++ b/src/components/TaskTracker/DeleteModal.tsx
@@ -1,6 +1,4 @@
 export const DeleteModal = ({ show, onCancel, onConfirm }) => {
-  //Toggle modal visibility
-
   return (
     <div className="modal">
       <div className="max-w-xs rounded-lg bg-white p-2 px-1 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">

--- a/src/components/TaskTracker/Task.tsx
+++ b/src/components/TaskTracker/Task.tsx
@@ -62,7 +62,6 @@ export const Task = ({ task, tasks }) => {
   };
 
   const handleDelete = () => {
-    // FIXME: This should be a modal
     setShowModal(true);
   };
 

--- a/src/components/TaskTracker/Task.tsx
+++ b/src/components/TaskTracker/Task.tsx
@@ -180,7 +180,7 @@ export const Task = ({ task, tasks }) => {
       </div>
       {showModal && (
         <div className=" absolute">
-          <DeleteModal show={showModal} onCancel={handleOnCancel} onConfirm={handleOnConfirm} />
+          <DeleteModal task={task} show={showModal} onCancel={handleOnCancel} onConfirm={handleOnConfirm} />
         </div>
       )}
     </>

--- a/src/components/TaskTracker/Task.tsx
+++ b/src/components/TaskTracker/Task.tsx
@@ -6,6 +6,7 @@ import { Settings } from "./Settings";
 import { useTask, useTimer, useBreakStarted } from "@Store";
 import clsx from "clsx";
 import { ITask } from "@Root/src/interfaces";
+import { DeleteModal } from "./DeleteModal";
 
 // TODO: Remove alerted
 // TODO: Add a blurb/instructions to let users know how to toggle
@@ -32,6 +33,7 @@ const onClickOff = callback => {
 
 export const Task = ({ task, tasks }) => {
   const [openSettings, setOpenSettings] = useState(false);
+  const [showModal, setShowModal] = useState(false);
   const { removeTask, setCompleted, toggleInProgressState, alertTask, setPomodoroCounter, toggleMenu } = useTask();
   const { breakStarted } = useBreakStarted();
   const { timerQueue } = useTimer();
@@ -50,10 +52,18 @@ export const Task = ({ task, tasks }) => {
     });
   };
 
+  const handleOnCancel = () => {
+    setShowModal(false);
+  };
+
+  const handleOnConfirm = () => {
+    removeTask(task.id);
+    setShowModal(false);
+  };
+
   const handleDelete = () => {
     // FIXME: This should be a modal
-    alert("Are you sure you want to delete this task?");
-    removeTask(task.id);
+    setShowModal(true);
   };
 
   /* Observation: When double clicking a task the text is highlighted
@@ -169,6 +179,11 @@ export const Task = ({ task, tasks }) => {
           </div>
         )}
       </div>
+      {showModal && (
+        <div className=" absolute">
+          <DeleteModal show={showModal} onCancel={handleOnCancel} onConfirm={handleOnConfirm} />
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/TaskTracker/TaskTracker.tsx
+++ b/src/components/TaskTracker/TaskTracker.tsx
@@ -5,6 +5,7 @@ import { AddTask } from "./AddTask";
 import { IoCloseSharp, IoInformationCircleOutline } from "react-icons/io5";
 import { useTask, useToggleTasks } from "@Store";
 import { TaskInfoModal } from "@App/components/TaskTracker/InfoModal";
+import { DeleteModal } from "./DeleteModal";
 
 export const TaskTracker = () => {
   const [showAddTask, setShowAddTask] = useState(false);
@@ -30,6 +31,7 @@ export const TaskTracker = () => {
         {showAddTask && <AddTask />}
         {tasks.length > 0 ? <Tasks tasks={tasks} /> : "No Tasks to Show"}
       </div>
+      <DeleteModal />
     </div>
   );
 };

--- a/src/components/TaskTracker/TaskTracker.tsx
+++ b/src/components/TaskTracker/TaskTracker.tsx
@@ -31,7 +31,7 @@ export const TaskTracker = () => {
         {showAddTask && <AddTask />}
         {tasks.length > 0 ? <Tasks tasks={tasks} /> : "No Tasks to Show"}
       </div>
-      <DeleteModal />
+      {/* <DeleteModal /> */}
     </div>
   );
 };

--- a/src/components/TaskTracker/TaskTracker.tsx
+++ b/src/components/TaskTracker/TaskTracker.tsx
@@ -5,7 +5,6 @@ import { AddTask } from "./AddTask";
 import { IoCloseSharp, IoInformationCircleOutline } from "react-icons/io5";
 import { useTask, useToggleTasks } from "@Store";
 import { TaskInfoModal } from "@App/components/TaskTracker/InfoModal";
-import { DeleteModal } from "./DeleteModal";
 
 export const TaskTracker = () => {
   const [showAddTask, setShowAddTask] = useState(false);
@@ -31,7 +30,6 @@ export const TaskTracker = () => {
         {showAddTask && <AddTask />}
         {tasks.length > 0 ? <Tasks tasks={tasks} /> : "No Tasks to Show"}
       </div>
-      {/* <DeleteModal /> */}
     </div>
   );
 };


### PR DESCRIPTION
Note this is still a work in progress! Putting a PR to preview the snippet of the modal in case anyone wants to check it out.

Current behavior: We have an alert box that pops up when a user wants to delete a task. Users only option is to press 'ok' and cannot cancel the deletion, nor press outside the alert box to cancel.

Intended behavior: We want a modal instead that is prompted when a user wants to delete a task. This modal will have the option to "delete" or "cancel", and the option to click outside the modal to cancel as well. 

<img width="382" alt="Screen Shot 2023-03-30 at 6 00 03 PM" src="https://user-images.githubusercontent.com/35973829/229395618-e92fa0cb-569a-4d13-9669-dc80ba13a2d1.png">
