### PR TITLE
Add Kanban board widget

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -12,3 +12,4 @@
 - royanger
 - Samathingamajig
 - cosmiclasagnadev
+- trobonox

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react-dom": "^17.0.2",
         "react-draggable": "^4.4.4",
         "react-hot-toast": "^2.2.0",
-        "react-icons": "^4.3.1",
+        "react-icons": "^4.8.0",
         "react-joyride": "^2.4.0",
         "react-router-dom": "^6.2.1",
         "react-textarea-autosize": "^8.3.3",
@@ -2956,9 +2956,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
       "peerDependencies": {
         "react": "*"
       }
@@ -5952,9 +5952,9 @@
       }
     },
     "react-icons": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^17.0.2",
     "react-draggable": "^4.4.4",
     "react-hot-toast": "^2.2.0",
-    "react-icons": "^4.3.1",
+    "react-icons": "^4.8.0",
     "react-joyride": "^2.4.0",
     "react-router-dom": "^6.2.1",
     "react-textarea-autosize": "^8.3.3",

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -61,7 +61,7 @@ const KanbanCard = ({ provided, taskIndex, task, deleteTask, updateTaskName }) =
           className="flex flex-grow-0 flex-row items-center justify-between rounded-md bg-gray-300 py-2 pl-2 pr-0.5 dark:bg-gray-600"
         >
           {!cardEditMode ? (
-            <span className="text-no-overflow align-middle">{task.name}</span>
+            <span className="break-words whitespace-normal overflow-hidden align-middle">{task.name}</span>
           ) : (
             <form onSubmit={e => onFormSubmit(e)}>
               <input
@@ -110,7 +110,7 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
       return;
     }
 
-    addTask(column.id, taskInputValue);
+    addTask(taskInputValue);
     setTaskInputValue("");
   }
 

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -5,7 +5,7 @@ import { IoCloseSharp } from "react-icons/io5";
 import { BsPlus } from "react-icons/bs";
 import { RxPencil2, RxCheck } from "react-icons/rx";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
-import { FormEvent, useCallback, useRef, useState } from "react";
+import { FormEvent, useCallback, useState } from "react";
 
 import { v4 } from "uuid";
 import useMediaQuery from "@Utils/hooks/useMediaQuery";
@@ -21,7 +21,6 @@ const KanbanCard = ({ provided, taskIndex, task, deleteTask, updateTaskName }) =
 
   const onFormSubmit = (event: FormEvent) => {
     event.preventDefault();
-
     setTaskName();
   }
 
@@ -103,8 +102,6 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
   const addTaskButtonRef = useCallback((element) => {
     element?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" });
   }, []);
-
-
 
   const onFormSubmit = (e: FormEvent) => {
     e.preventDefault();

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -127,7 +127,7 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
             <div className="flex h-full w-full mb-4 flex-grow-0 flex-col gap-2 overflow-auto">
               <h2 className="font-bold">{column.title}</h2>
               <div className="flex h-full flex-col justify-between gap-2 overflow-y-auto">
-                <div className="flex flex-col gap-2 pr-1 min-h-[240px]">
+                <div className="flex flex-col gap-2 pr-1 min-h-[160px]">
                   {column.tasks.map((task, index) => (
                     <KanbanCard
                       task={task}

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -124,10 +124,10 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
       {provided => {
         return (
           <div ref={provided.innerRef} {...provided.droppableProps} className="w-1/3">
-            <div className="flex h-full w-full mb-4 flex-grow-0 flex-col gap-2 overflow-auto rounded-md border border-gray-200 p-2 dark:border-gray-700">
+            <div className="flex h-full w-full mb-4 flex-grow-0 flex-col gap-2 overflow-auto">
               <h2 className="font-bold">{column.title}</h2>
               <div className="flex h-full flex-col justify-between gap-2 overflow-y-auto">
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-2 pr-1">
                   {column.tasks.map((task, index) => (
                     <KanbanCard
                       task={task}
@@ -150,25 +150,27 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
                     </button>
                   ) : (
                     <form onSubmit={e => onFormSubmit(e)}>
-                      <input
-                        autoFocus
-                        value={taskInputValue}
-                        onChange={event => {
-                          setTaskInputValue(event.target.value);
-                        }}
-                        placeholder="Enter a task name..."
-                        className="mb-2 w-full rounded-sm border border-gray-300 p-1 dark:border-gray-500 dark:bg-gray-700"
-                      />
-                      <div className="flex w-full flex-row gap-1">
-                        <button ref={addTaskButtonRef} className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700">
-                          Add Task
-                        </button>
-                        <button
-                          className="rounded-md px-2 py-0.5 hover:bg-gray-300 dark:hover:bg-gray-600"
-                          onClick={() => setTaskInputValue("")}
-                        >
-                          Cancel
-                        </button>
+                      <div className="px-1">
+                        <input
+                          autoFocus
+                          value={taskInputValue}
+                          onChange={event => {
+                            setTaskInputValue(event.target.value);
+                          }}
+                          placeholder="Enter a task name..."
+                          className="mb-2 w-full overflow-hidden rounded-sm border border-gray-300 p-1 dark:border-gray-500 dark:bg-gray-700"
+                        />
+                        <div className="flex w-full flex-row gap-1">
+                          <button ref={addTaskButtonRef} className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700">
+                            Add Task
+                          </button>
+                          <button
+                            className="rounded-md px-2 py-0.5 hover:bg-gray-300 dark:hover:bg-gray-600"
+                            onClick={() => setTaskInputValue("")}
+                          >
+                            Cancel
+                          </button>
+                        </div>
                       </div>
                     </form>
                   )}

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -4,11 +4,10 @@ import { IconContext } from "react-icons";
 import { IoCloseSharp } from "react-icons/io5";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { useState } from "react";
+import { BsPlus } from "react-icons/bs";
 
-const KanbanColumn = ({ column, deleteTask }) => {
-  const test = () => {
-    console.log("pog");
-  }
+const KanbanColumn = ({ column, addTask, deleteTask }) => {
+  const [taskAddMode, setTaskAddMode] = useState(false);
 
   return (
     <Droppable key={column.id} droppableId={column.id}>
@@ -19,36 +18,42 @@ const KanbanColumn = ({ column, deleteTask }) => {
             {...provided.droppableProps}
             className="w-full"
           >
-            <div className="flex h-64 w-full flex-col gap-2 overflow-auto rounded-md border border-gray-700 p-2">
-              <h2 className="font-bold">{column.title}</h2>
-              {column.tasks.map((task, index) => {
-                return (
-                  <Draggable
-                    key={task.id}
-                    draggableId={task.id}
-                    index={index}
-                  >
-                    {(provided) => (
-                      <div
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        style={{
-                          ...provided.draggableProps.style,
-                          userSelect: "none",
-                        }}
-                        className="rounded-md bg-gray-600 py-2 pl-2 pr-1 flex flex-row justify-between items-center"
-                      >
-                        <span className="align-middle">{task.name}</span>
-                        <div className="grow-0">
-                          <IoCloseSharp onClick={() => deleteTask(index)} className="cursor-pointer text-gray-400 hover:bg-gray-500 rounded-md w-6 h-6 px-1 grow-0" />
+            <div className="flex h-64 w-full flex-col gap-2 overflow-auto rounded-md border border-gray-700 p-2 justify-between">
+              <div className="flex flex-col gap-2">
+                <h2 className="font-bold">{column.title}</h2>
+                {column.tasks.map((task, index) => {
+                  return (
+                    <Draggable
+                      key={task.id}
+                      draggableId={task.id}
+                      index={index}
+                    >
+                      {(provided) => (
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          style={{
+                            ...provided.draggableProps.style,
+                            userSelect: "none",
+                          }}
+                          className="rounded-md bg-gray-600 py-2 pl-2 pr-1 flex flex-row justify-between items-center"
+                        >
+                          <span className="align-middle">{task.name}</span>
+                          <div className="grow-0">
+                            <IoCloseSharp onClick={() => deleteTask(index)} className="cursor-pointer text-gray-400 hover:bg-gray-500 rounded-md w-6 h-6 px-1 grow-0" />
+                          </div>
                         </div>
-                      </div>
-                    )}
-                  </Draggable>
-                );
-              })}
-              {provided.placeholder}
+                      )}
+                    </Draggable>
+                  );
+                })}
+                {provided.placeholder}
+              </div>
+              <button className="text-left hover:bg-gray-600 rounded-md px-1 flex flex-row gap-1 items-center" onClick={() => addTask(column.id)}>
+                <BsPlus className="h-6 w-6" />
+                <span className="align-middle">Add Task</span>
+              </button>
             </div>
           </div>
         );
@@ -62,10 +67,20 @@ export const Kanban = ({}) => {
 
   const { board, setColumns } = useKanban();
 
-  const addTask = (_, column) => { };
+  const addTask = (columnId: string) => {
+    console.log(columnId);
+  };
 
-  const deleteTask = (taskIndex: number, columnId: string) => {
-    console.log(taskIndex, columnId);
+  const delTask = (taskIndex: number, columnId: string) => {
+    const column = board.columns.filter((obj) => {
+      return obj.id === columnId;
+    })[0];
+    const columnIndex = board.columns.indexOf(column);
+
+    let columns = board.columns;
+    columns[columnIndex].tasks.splice(taskIndex, 1);
+
+    setColumns(columns);
   }
 
   const onDragEnd = (result) => {
@@ -115,7 +130,7 @@ export const Kanban = ({}) => {
           <DragDropContext onDragEnd={onDragEnd}>
             <div className="w-full flex flex-row gap-2">
               {board.columns.map((column) => (
-                <KanbanColumn column={column} deleteTask={(passedIndex) => deleteTask(passedIndex, column.id)} />
+                <KanbanColumn key={column.id} column={column} addTask={(columnId) => addTask(columnId)} deleteTask={(passedIndex) => delTask(passedIndex, column.id)} />
               ))}
             </div>
           </DragDropContext>

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -30,69 +30,73 @@ const KanbanColumn = ({ column, addTask, deleteTask }) => {
       {provided => {
         return (
           <div ref={provided.innerRef} {...provided.droppableProps} className="w-full">
-            <div className="flex h-64 w-full flex-col justify-between gap-2 overflow-auto rounded-md border dark:border-gray-700 border-gray-200 p-2">
-              <div className="flex flex-col gap-2">
-                <h2 className="font-bold">{column.title}</h2>
-                {column.tasks.map((task, index) => {
-                  return (
-                    <Draggable key={task.id} draggableId={task.id} index={index}>
-                      {provided => (
-                        <div
-                          ref={provided.innerRef}
-                          {...provided.draggableProps}
-                          {...provided.dragHandleProps}
-                          style={{
-                            ...provided.draggableProps.style,
-                            userSelect: "none",
-                          }}
-                          className="flex flex-row items-center justify-between rounded-md dark:bg-gray-600 bg-gray-300 py-2 pl-2 pr-1"
-                        >
-                          <span className="align-middle">{task.name}</span>
-                          <div className="grow-0">
-                            <IoCloseSharp
-                              onClick={() => deleteTask(index)}
-                              className="h-6 w-6 grow-0 cursor-pointer rounded-md px-1 text-gray-400 dark:hover:bg-gray-500 hover:bg-gray-200"
-                            />
+            <div className="flex h-64 w-full max-w-[200px] flex-col gap-2 overflow-auto rounded-md border border-gray-200 p-2 dark:border-gray-700 flex-grow-0">
+              <h2 className="font-bold">{column.title}</h2>
+              <div className="flex flex-col gap-2 overflow-y-auto justify-between h-full">
+                <div className="flex flex-col gap-2">
+                  {column.tasks.map((task, index) => {
+                    return (
+                      <Draggable key={task.id} draggableId={task.id} index={index}>
+                        {provided => (
+                          <div
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            {...provided.dragHandleProps}
+                            style={{
+                              ...provided.draggableProps.style,
+                              userSelect: "none",
+                            }}
+                            className="flex flex-grow-0 flex-row items-center justify-between rounded-md bg-gray-300 py-2 pl-2 pr-1 dark:bg-gray-600"
+                          >
+                            <span className="text-no-overflow align-middle">{task.name}</span>
+                            <div className="grow-0">
+                              <IoCloseSharp
+                                onClick={() => deleteTask(index)}
+                                className="h-6 w-6 grow-0 cursor-pointer rounded-md px-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-500"
+                              />
+                            </div>
                           </div>
-                        </div>
-                      )}
-                    </Draggable>
-                  );
-                })}
-                {provided.placeholder}
-              </div>
-              {!taskAddMode ? (
-                <button
-                  className="flex flex-row items-center gap-1 rounded-md px-1 text-left dark:hover:bg-gray-600 hover:bg-gray-200"
-                  onClick={() => setTaskAddMode(true)}
-                >
-                  <BsPlus className="h-6 w-6" />
-                  <span className="align-middle">Add Task</span>
-                </button>
-              ) : (
-                <form onSubmit={e => onFormSubmit(e)}>
-                  <input
-                    autoFocus
-                    value={taskInputValue}
-                    onChange={event => {
-                      setTaskInputValue(event.target.value);
-                    }}
-                    placeholder="Enter a task name..."
-                    className="mb-2 w-full rounded-sm border border-gray-300 p-1 dark:border-gray-500 dark:bg-gray-700"
-                  />
-                  <div className="flex w-full flex-row gap-1">
-                    <button className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700">
-                      Add Task
-                    </button>
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {provided.placeholder}
+                </div>
+                <div className="w-full">
+                  {!taskAddMode ? (
                     <button
-                      className="rounded-md px-2 py-0.5 hover:bg-gray-300 dark:hover:bg-gray-600"
-                      onClick={() => setTaskInputValue("")}
+                      className="flex flex-row items-center gap-1 rounded-md px-1 text-left hover:bg-gray-200 dark:hover:bg-gray-600 w-full"
+                      onClick={() => setTaskAddMode(true)}
                     >
-                      Cancel
+                      <BsPlus className="h-6 w-6" />
+                      <span className="align-middle">Add Task</span>
                     </button>
-                  </div>
-                </form>
-              )}
+                  ) : (
+                    <form onSubmit={e => onFormSubmit(e)}>
+                      <input
+                        autoFocus
+                        value={taskInputValue}
+                        onChange={event => {
+                          setTaskInputValue(event.target.value);
+                        }}
+                        placeholder="Enter a task name..."
+                        className="mb-2 w-full rounded-sm border border-gray-300 p-1 dark:border-gray-500 dark:bg-gray-700"
+                      />
+                      <div className="flex w-full flex-row gap-1">
+                        <button className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700">
+                          Add Task
+                        </button>
+                        <button
+                          className="rounded-md px-2 py-0.5 hover:bg-gray-300 dark:hover:bg-gray-600"
+                          onClick={() => setTaskInputValue("")}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </form>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
         );

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -2,13 +2,92 @@ import "@Components/Kanban/kanban.css";
 import { useKanban, useToggleKanban } from "@Root/src/store";
 import { IconContext } from "react-icons";
 import { IoCloseSharp } from "react-icons/io5";
+import { BsPlus, BsCheck } from "react-icons/bs";
+import { RxPencil2, RxCheck } from "react-icons/rx";
+import { BiCheck } from "react-icons/bi"
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { FormEvent, useState } from "react";
-import { BsPlus } from "react-icons/bs";
+
 import { v4 } from "uuid";
 import useMediaQuery from "@Utils/hooks/useMediaQuery";
 
-const KanbanColumn = ({ column, addTask, deleteTask }) => {
+const KanbanCard = ({ provided, taskIndex, task, deleteTask, updateTaskName }) => {
+  const [cardEditMode, setCardEditMode] = useState(false);
+  const [cardInputValue, setCardInputValue] = useState(task.name);
+
+  const enableTaskEdit = () => {
+    setCardInputValue(task.name);
+    setCardEditMode(true);
+  }
+
+  const onFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+
+    setTaskName();
+  }
+
+  const setTaskName = () => {
+    setCardEditMode(false);
+
+    if (cardInputValue === "" || !/\S/.test(cardInputValue)) {
+      setCardInputValue("");
+      return;
+    }
+
+    updateTaskName(taskIndex, cardInputValue);
+  }
+
+  return (
+    <Draggable key={task.id} draggableId={task.id} index={taskIndex}>
+      {provided => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          style={{
+            ...provided.draggableProps.style,
+            userSelect: "none",
+          }}
+          className="flex flex-grow-0 flex-row items-center justify-between rounded-md bg-gray-300 py-2 pl-2 pr-0.5 dark:bg-gray-600"
+        >
+          {!cardEditMode ? (
+            <span className="text-no-overflow align-middle">{task.name}</span>
+          ) : (
+            <form onSubmit={e => onFormSubmit(e)}>
+              <input
+                className="w-full text-gray-800"
+                autoFocus
+                value={cardInputValue}
+                onChange={event => {
+                  setCardInputValue(event.target.value);
+                }}
+              />
+            </form>
+          )}
+          <div className="flex grow-0 flex-row items-center">
+            {!cardEditMode ? (
+              <RxPencil2
+                onClick={() => enableTaskEdit()}
+                className="h-6 w-6 grow-0 cursor-pointer rounded-md py-1 px-0 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-500"
+              />
+            ) : (
+              <RxCheck
+                onClick={() => setTaskName()}
+                className="h-6 w-6 grow-0 cursor-pointer rounded-md py-1 px-0 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-500"
+              />
+            )}
+            <IoCloseSharp
+              onClick={() => deleteTask(taskIndex)}
+              className="h-6 w-6 grow-0 cursor-pointer rounded-md py-1 px-0 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-500"
+            />
+          </div>
+        </div>
+      )}
+    </Draggable>
+  );
+}
+
+const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
   const [taskAddMode, setTaskAddMode] = useState(false);
   const [taskInputValue, setTaskInputValue] = useState("");
 
@@ -30,42 +109,25 @@ const KanbanColumn = ({ column, addTask, deleteTask }) => {
       {provided => {
         return (
           <div ref={provided.innerRef} {...provided.droppableProps} className="w-full">
-            <div className="flex h-64 w-full max-w-[200px] flex-col gap-2 overflow-auto rounded-md border border-gray-200 p-2 dark:border-gray-700 flex-grow-0">
+            <div className="flex h-64 w-full max-w-[200px] flex-grow-0 flex-col gap-2 overflow-auto rounded-md border border-gray-200 p-2 dark:border-gray-700">
               <h2 className="font-bold">{column.title}</h2>
-              <div className="flex flex-col gap-2 overflow-y-auto justify-between h-full">
+              <div className="flex h-full flex-col justify-between gap-2 overflow-y-auto">
                 <div className="flex flex-col gap-2">
-                  {column.tasks.map((task, index) => {
-                    return (
-                      <Draggable key={task.id} draggableId={task.id} index={index}>
-                        {provided => (
-                          <div
-                            ref={provided.innerRef}
-                            {...provided.draggableProps}
-                            {...provided.dragHandleProps}
-                            style={{
-                              ...provided.draggableProps.style,
-                              userSelect: "none",
-                            }}
-                            className="flex flex-grow-0 flex-row items-center justify-between rounded-md bg-gray-300 py-2 pl-2 pr-1 dark:bg-gray-600"
-                          >
-                            <span className="text-no-overflow align-middle">{task.name}</span>
-                            <div className="grow-0">
-                              <IoCloseSharp
-                                onClick={() => deleteTask(index)}
-                                className="h-6 w-6 grow-0 cursor-pointer rounded-md px-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-500"
-                              />
-                            </div>
-                          </div>
-                        )}
-                      </Draggable>
-                    );
-                  })}
+                  {column.tasks.map((task, index) => (
+                    <KanbanCard
+                      task={task}
+                      taskIndex={index}
+                      provided={provided}
+                      deleteTask={taskIndex => deleteTask(taskIndex)}
+                      updateTaskName={(taskIndex, name) => updateTaskName(taskIndex, name)}
+                    />
+                  ))}
                   {provided.placeholder}
                 </div>
                 <div className="w-full">
                   {!taskAddMode ? (
                     <button
-                      className="flex flex-row items-center gap-1 rounded-md px-1 text-left hover:bg-gray-200 dark:hover:bg-gray-600 w-full"
+                      className="flex w-full flex-row items-center gap-1 rounded-md px-1 text-left hover:bg-gray-200 dark:hover:bg-gray-600"
                       onClick={() => setTaskAddMode(true)}
                     >
                       <BsPlus className="h-6 w-6" />
@@ -110,33 +172,28 @@ export const Kanban = ({}) => {
   const { board, setColumns } = useKanban();
   const isDesktop = useMediaQuery("(min-width: 641px)");
 
-  const addTask = (columnId: string, taskName: string) => {
-    const column = board.columns.filter(obj => {
-      return obj.id === columnId;
-    })[0];
-    const columnIndex = board.columns.indexOf(column);
-
+  const addTask = (columnIndex: number, taskName: string) => {
     let columns = board.columns;
     columns[columnIndex].tasks.push({ id: v4(), name: taskName });
 
     setColumns(columns);
   };
 
-  const deleteTask = (taskIndex: number, columnId: string) => {
-    const column = board.columns.filter(obj => {
-      return obj.id === columnId;
-    })[0];
-    const columnIndex = board.columns.indexOf(column);
-
+  const deleteTask = (columnIndex: number, taskIndex: number) => {
     let columns = board.columns;
 
-    if (!confirm(`Are you sure you want to delete the task "${columns[columnIndex].tasks[taskIndex].name}"?`)) {
+    if (!confirm(`Are you sure you want to delete the task "${columns[columnIndex].tasks[taskIndex].name}"?`))
       return;
-    }
 
     columns[columnIndex].tasks.splice(taskIndex, 1);
     setColumns(columns);
   };
+
+  const updateTaskName = (columnIndex: number, taskIndex: number, name: string) => {
+    let columns = board.columns;
+    columns[columnIndex].tasks[taskIndex].name = name;
+    setColumns(columns);
+  }
 
   const onDragEnd = result => {
     const { destination, source, draggableId } = result;
@@ -175,12 +232,13 @@ export const Kanban = ({}) => {
         <div className="cancelDrag flex h-full w-full flex-row items-center gap-2">
           <DragDropContext onDragEnd={onDragEnd}>
             <div className={`flex w-full gap-2 ${isDesktop ? "flex-row" : "flex-col"}`}>
-              {board.columns.map(column => (
+              {board.columns.map((column, columnIndex) => (
                 <KanbanColumn
                   key={column.id}
                   column={column}
-                  addTask={(columnId, taskName) => addTask(columnId, taskName)}
-                  deleteTask={passedIndex => deleteTask(passedIndex, column.id)}
+                  addTask={(taskName) => addTask(columnIndex, taskName)}
+                  deleteTask={passedIndex => deleteTask(columnIndex, passedIndex)}
+                  updateTaskName={(taskIndex, name) => updateTaskName(columnIndex, taskIndex, name)}
                 />
               ))}
             </div>

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -46,7 +46,7 @@ const KanbanCard = ({ provided, taskIndex, task, deleteTask, updateTaskName }) =
   }
 
   return (
-    <Draggable key={task.id} draggableId={task.id} index={taskIndex}>
+    <Draggable key={task.id} draggableId={task.id} index={taskIndex} isDragDisabled={cardEditMode}>
       {provided => (
         <div
           ref={provided.innerRef}

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -1,41 +1,72 @@
 import "@Components/Kanban/kanban.css";
-import { useToggleKanban } from "@Root/src/store";
+import { useKanban, useToggleKanban } from "@Root/src/store";
 import { IconContext } from "react-icons";
 import { IoCloseSharp } from "react-icons/io5";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { useState } from "react";
 
+const KanbanColumn = ({ column, deleteTask }) => {
+  const test = () => {
+    console.log("pog");
+  }
+
+  return (
+    <Droppable key={column.id} droppableId={column.id}>
+      {(provided) => {
+        return (
+          <div
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+            className="w-full"
+          >
+            <div className="flex h-64 w-full flex-col gap-2 overflow-auto rounded-md border border-gray-700 p-2">
+              <h2 className="font-bold">{column.title}</h2>
+              {column.tasks.map((task, index) => {
+                return (
+                  <Draggable
+                    key={task.id}
+                    draggableId={task.id}
+                    index={index}
+                  >
+                    {(provided) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                        {...provided.dragHandleProps}
+                        style={{
+                          ...provided.draggableProps.style,
+                          userSelect: "none",
+                        }}
+                        className="rounded-md bg-gray-600 py-2 pl-2 pr-1 flex flex-row justify-between items-center"
+                      >
+                        <span className="align-middle">{task.name}</span>
+                        <div className="grow-0">
+                          <IoCloseSharp onClick={() => deleteTask(index)} className="cursor-pointer text-gray-400 hover:bg-gray-500 rounded-md w-6 h-6 px-1 grow-0" />
+                        </div>
+                      </div>
+                    )}
+                  </Draggable>
+                );
+              })}
+              {provided.placeholder}
+            </div>
+          </div>
+        );
+      }}
+    </Droppable>
+  )
+}
+
 export const Kanban = ({}) => {
   const { isKanbanToggled, setIsKanbanToggled } = useToggleKanban();
 
-  const [columns, setColumns] = useState([
-    {
-      id: "n23fnj3mfa073ad",
-      title: "To Do",
-      tasks: [
-        { id: "9nan529dab2495", name: "Example Task" },
-        { id: "nd35gna205ndz2", name: "Nice Task" },
-      ],
-    },
-    {
-      id: "za9w4550snadi23",
-      title: "In Progress",
-      tasks: [
-        { id: "jfiojijaw523a5", name: "Very nice Task" },
-        { id: "onbz237gwue25h", name: "Interesting Task" },
-      ],
-    },
-    {
-      id: "kl323dn3ai23ndaw",
-      title: "Done",
-      tasks: [
-        { id: "99dua235madiok", name: "Finished Task 1" },
-        { id: "jdo235hadu298a", name: "Finished Task 2" },
-      ],
-    },
-  ]);
+  const { board, setColumns } = useKanban();
 
-  const addTask = (_, column) => {};
+  const addTask = (_, column) => { };
+
+  const deleteTask = (taskIndex: number, columnId: string) => {
+    console.log(taskIndex, columnId);
+  }
 
   const onDragEnd = (result) => {
     const { destination, source, draggableId } = result;
@@ -51,8 +82,8 @@ export const Kanban = ({}) => {
       return;
     }
 
-    const sourceColumn = columns.find((col) => col.id === source.droppableId);
-    const destColumn = columns.find(
+    const sourceColumn = board.columns.find((col) => col.id === source.droppableId);
+    const destColumn = board.columns.find(
       (col) => col.id === destination.droppableId
     );
 
@@ -63,7 +94,7 @@ export const Kanban = ({}) => {
     sourceColumn.tasks.splice(source.index, 1);
     destColumn.tasks.splice(destination.index, 0, draggedTask);
 
-    setColumns([...columns]);
+    setColumns([...board.columns]);
   };
 
   return (
@@ -82,48 +113,11 @@ export const Kanban = ({}) => {
         </div>
         <div className="cancelDrag flex h-full w-full flex-row items-center gap-2">
           <DragDropContext onDragEnd={onDragEnd}>
-            {columns.map((column) => (
-              <Droppable key={column.id} droppableId={column.id}>
-                {(provided) => {
-                  return (
-                    <div
-                      ref={provided.innerRef}
-                      {...provided.droppableProps}
-                      className="w-full"
-                    >
-                      <div className="flex h-64 w-full flex-col gap-2 overflow-auto rounded-md border border-gray-700 p-2">
-                        <h2 className="font-bold">{column.title}</h2>
-                        {column.tasks.map((task, index) => {
-                          return (
-                            <Draggable
-                              key={task.id}
-                              draggableId={task.id}
-                              index={index}
-                            >
-                              {(provided) => (
-                                <div
-                                  ref={provided.innerRef}
-                                  {...provided.draggableProps}
-                                  {...provided.dragHandleProps}
-                                  style={{
-                                    ...provided.draggableProps.style,
-                                    userSelect: "none",
-                                  }}
-                                  className="rounded-md bg-gray-600 p-2"
-                                >
-                                  {task.name}
-                                </div>
-                              )}
-                            </Draggable>
-                          );
-                        })}
-                        {provided.placeholder}
-                      </div>
-                    </div>
-                  );
-                }}
-              </Droppable>
-            ))}
+            <div className="w-full flex flex-row gap-2">
+              {board.columns.map((column) => (
+                <KanbanColumn column={column} deleteTask={(passedIndex) => deleteTask(passedIndex, column.id)} />
+              ))}
+            </div>
           </DragDropContext>
         </div>
       </div>

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -37,6 +37,16 @@ const KanbanCard = ({ provided, taskIndex, task, deleteTask, updateTaskName }) =
     updateTaskName(taskIndex, cardInputValue);
   }
 
+  const delTask = (taskIndex: number) => {
+    if (cardEditMode) {
+      setCardEditMode(false);
+      setCardInputValue(task.name);
+      return
+    };
+
+    deleteTask(taskIndex);
+  }
+
   return (
     <Draggable key={task.id} draggableId={task.id} index={taskIndex}>
       {provided => (
@@ -77,7 +87,7 @@ const KanbanCard = ({ provided, taskIndex, task, deleteTask, updateTaskName }) =
               />
             )}
             <IoCloseSharp
-              onClick={() => deleteTask(taskIndex)}
+              onClick={() => delTask(taskIndex)}
               className="h-6 w-6 grow-0 cursor-pointer rounded-md py-1 px-0 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-500"
             />
           </div>

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -123,8 +123,8 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
     <Droppable key={column.id} droppableId={column.id}>
       {provided => {
         return (
-          <div ref={provided.innerRef} {...provided.droppableProps} className="w-full">
-            <div className="flex h-64 w-full max-w-[200px] flex-grow-0 flex-col gap-2 overflow-auto rounded-md border border-gray-200 p-2 dark:border-gray-700">
+          <div ref={provided.innerRef} {...provided.droppableProps} className="w-1/3">
+            <div className="flex h-full w-full mb-4 flex-grow-0 flex-col gap-2 overflow-auto rounded-md border border-gray-200 p-2 dark:border-gray-700">
               <h2 className="font-bold">{column.title}</h2>
               <div className="flex h-full flex-col justify-between gap-2 overflow-y-auto">
                 <div className="flex flex-col gap-2">
@@ -233,8 +233,8 @@ export const Kanban = ({}) => {
   };
 
   return (
-    <div className="my-2 w-72 rounded-lg border border-gray-200 bg-white/[.96] py-4 px-3 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800/[.96] dark:text-gray-300 sm:w-[40rem]">
-      <div className="flex w-full flex-col">
+    <div className="w-full resize justify-between overflow-auto my-2 rounded-lg border border-gray-200 bg-white/[.96] py-4 px-3 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800/[.96] dark:text-gray-300 sm:w-[40rem]">
+      <div className="flex w-full h-full flex-col">
         <div className="mb-2 flex flex-row items-center justify-between">
           <h1 className="font-bold text-gray-800 dark:text-white">Kanban board</h1>
           <IconContext.Provider value={{ size: "1.1rem" }}>
@@ -244,14 +244,14 @@ export const Kanban = ({}) => {
             />
           </IconContext.Provider>
         </div>
-        <div className="cancelDrag flex h-full w-full flex-row items-center gap-2">
+        <div className="cancelDrag flex h-full w-full flex-row items-center gap-2 overflow-hidden">
           <DragDropContext onDragEnd={onDragEnd}>
             <div className={`flex w-full gap-2 ${isDesktop ? "flex-row" : "flex-col"}`}>
               {board.columns.map((column, columnIndex) => (
                 <KanbanColumn
                   key={column.id}
                   column={column}
-                  addTask={(taskName) => addTask(columnIndex, taskName)}
+                  addTask={taskName => addTask(columnIndex, taskName)}
                   deleteTask={passedIndex => deleteTask(columnIndex, passedIndex)}
                   updateTaskName={(taskIndex, name) => updateTaskName(columnIndex, taskIndex, name)}
                 />

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -2,11 +2,10 @@ import "@Components/Kanban/kanban.css";
 import { useKanban, useToggleKanban } from "@Root/src/store";
 import { IconContext } from "react-icons";
 import { IoCloseSharp } from "react-icons/io5";
-import { BsPlus, BsCheck } from "react-icons/bs";
+import { BsPlus } from "react-icons/bs";
 import { RxPencil2, RxCheck } from "react-icons/rx";
-import { BiCheck } from "react-icons/bi"
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
-import { FormEvent, useState } from "react";
+import { FormEvent, useCallback, useRef, useState } from "react";
 
 import { v4 } from "uuid";
 import useMediaQuery from "@Utils/hooks/useMediaQuery";
@@ -101,6 +100,12 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
   const [taskAddMode, setTaskAddMode] = useState(false);
   const [taskInputValue, setTaskInputValue] = useState("");
 
+  const addTaskButtonRef = useCallback((element) => {
+    element?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" });
+  }, []);
+
+
+
   const onFormSubmit = (e: FormEvent) => {
     e.preventDefault();
 
@@ -155,7 +160,7 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
                         className="mb-2 w-full rounded-sm border border-gray-300 p-1 dark:border-gray-500 dark:bg-gray-700"
                       />
                       <div className="flex w-full flex-row gap-1">
-                        <button className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700">
+                        <button ref={addTaskButtonRef} className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700">
                           Add Task
                         </button>
                         <button

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -1,0 +1,132 @@
+import "@Components/Kanban/kanban.css";
+import { useToggleKanban } from "@Root/src/store";
+import { IconContext } from "react-icons";
+import { IoCloseSharp } from "react-icons/io5";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+import { useState } from "react";
+
+export const Kanban = ({}) => {
+  const { isKanbanToggled, setIsKanbanToggled } = useToggleKanban();
+
+  const [columns, setColumns] = useState([
+    {
+      id: "n23fnj3mfa073ad",
+      title: "To Do",
+      tasks: [
+        { id: "9nan529dab2495", name: "Example Task" },
+        { id: "nd35gna205ndz2", name: "Nice Task" },
+      ],
+    },
+    {
+      id: "za9w4550snadi23",
+      title: "In Progress",
+      tasks: [
+        { id: "jfiojijaw523a5", name: "Very nice Task" },
+        { id: "onbz237gwue25h", name: "Interesting Task" },
+      ],
+    },
+    {
+      id: "kl323dn3ai23ndaw",
+      title: "Done",
+      tasks: [
+        { id: "99dua235madiok", name: "Finished Task 1" },
+        { id: "jdo235hadu298a", name: "Finished Task 2" },
+      ],
+    },
+  ]);
+
+  const addTask = (_, column) => {};
+
+  const onDragEnd = (result) => {
+    const { destination, source, draggableId } = result;
+
+    if (!destination) {
+      return;
+    }
+
+    if (
+      destination.droppableId === source.droppableId &&
+      destination.index === source.index
+    ) {
+      return;
+    }
+
+    const sourceColumn = columns.find((col) => col.id === source.droppableId);
+    const destColumn = columns.find(
+      (col) => col.id === destination.droppableId
+    );
+
+    const draggedTask = sourceColumn.tasks.find(
+      (task) => task.id === draggableId
+    );
+
+    sourceColumn.tasks.splice(source.index, 1);
+    destColumn.tasks.splice(destination.index, 0, draggedTask);
+
+    setColumns([...columns]);
+  };
+
+  return (
+    <div className="mb-2 w-72 rounded-lg border border-gray-200 bg-white/[.96] py-4 px-3 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800/[.96] dark:text-gray-300 sm:w-[40rem]">
+      <div className="flex w-full flex-col">
+        <div className="mb-2 flex flex-row items-center justify-between">
+          <h1 className="font-bold text-gray-800 dark:text-white">
+            Kanban board
+          </h1>
+          <IconContext.Provider value={{ size: "1.1rem" }}>
+            <IoCloseSharp
+              className="cursor-pointer text-red-500 hover:bg-red-200"
+              onClick={() => setIsKanbanToggled(false)}
+            />
+          </IconContext.Provider>
+        </div>
+        <div className="cancelDrag flex h-full w-full flex-row items-center gap-2">
+          <DragDropContext onDragEnd={onDragEnd}>
+            {columns.map((column) => (
+              <Droppable key={column.id} droppableId={column.id}>
+                {(provided) => {
+                  return (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      className="w-full"
+                    >
+                      <div className="flex h-64 w-full flex-col gap-2 overflow-auto rounded-md border border-gray-700 p-2">
+                        <h2 className="font-bold">{column.title}</h2>
+                        {column.tasks.map((task, index) => {
+                          return (
+                            <Draggable
+                              key={task.id}
+                              draggableId={task.id}
+                              index={index}
+                            >
+                              {(provided) => (
+                                <div
+                                  ref={provided.innerRef}
+                                  {...provided.draggableProps}
+                                  {...provided.dragHandleProps}
+                                  style={{
+                                    ...provided.draggableProps.style,
+                                    userSelect: "none",
+                                  }}
+                                  className="rounded-md bg-gray-600 p-2"
+                                >
+                                  {task.name}
+                                </div>
+                              )}
+                            </Draggable>
+                          );
+                        })}
+                        {provided.placeholder}
+                      </div>
+                    </div>
+                  );
+                }}
+              </Droppable>
+            ))}
+          </DragDropContext>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -120,7 +120,7 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
     <Droppable key={column.id} droppableId={column.id}>
       {provided => {
         return (
-          <div ref={provided.innerRef} {...provided.droppableProps} className="w-1/3">
+          <div ref={provided.innerRef} {...provided.droppableProps} className="w-full md:w-1/3">
             <div className="mb-4 flex h-full w-full flex-grow-0 flex-col gap-2 overflow-auto">
               <h2 className="font-bold">{column.title}</h2>
               <div className="flex h-full flex-col justify-between gap-2 overflow-y-auto">
@@ -246,7 +246,7 @@ export const Kanban = ({}) => {
         </div>
         <div className="cancelDrag flex h-full w-full flex-row items-center gap-2 overflow-hidden">
           <DragDropContext onDragEnd={onDragEnd}>
-            <div className={`flex w-full h-full gap-2 ${isDesktop ? "flex-row" : "flex-col"}`}>
+            <div className={`flex w-full h-full gap-2 min-w-[250px] ${isDesktop ? "flex-row" : "flex-col"}`}>
               {board.columns.map((column, columnIndex) => (
                 <KanbanColumn
                   key={column.id}

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -127,7 +127,7 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
             <div className="flex h-full w-full mb-4 flex-grow-0 flex-col gap-2 overflow-auto">
               <h2 className="font-bold">{column.title}</h2>
               <div className="flex h-full flex-col justify-between gap-2 overflow-y-auto">
-                <div className="flex flex-col gap-2 pr-1">
+                <div className="flex flex-col gap-2 pr-1 min-h-[240px]">
                   {column.tasks.map((task, index) => (
                     <KanbanCard
                       task={task}

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -29,7 +29,7 @@ const KanbanColumn = ({ column, addTask, deleteTask }) => {
       {provided => {
         return (
           <div ref={provided.innerRef} {...provided.droppableProps} className="w-full">
-            <div className="flex h-64 w-full flex-col justify-between gap-2 overflow-auto rounded-md border border-gray-700 p-2">
+            <div className="flex h-64 w-full flex-col justify-between gap-2 overflow-auto rounded-md border dark:border-gray-700 border-gray-200 p-2">
               <div className="flex flex-col gap-2">
                 <h2 className="font-bold">{column.title}</h2>
                 {column.tasks.map((task, index) => {
@@ -44,13 +44,13 @@ const KanbanColumn = ({ column, addTask, deleteTask }) => {
                             ...provided.draggableProps.style,
                             userSelect: "none",
                           }}
-                          className="flex flex-row items-center justify-between rounded-md bg-gray-600 py-2 pl-2 pr-1"
+                          className="flex flex-row items-center justify-between rounded-md dark:bg-gray-600 bg-gray-300 py-2 pl-2 pr-1"
                         >
                           <span className="align-middle">{task.name}</span>
                           <div className="grow-0">
                             <IoCloseSharp
                               onClick={() => deleteTask(index)}
-                              className="h-6 w-6 grow-0 cursor-pointer rounded-md px-1 text-gray-400 hover:bg-gray-500"
+                              className="h-6 w-6 grow-0 cursor-pointer rounded-md px-1 text-gray-400 dark:hover:bg-gray-500 hover:bg-gray-200"
                             />
                           </div>
                         </div>
@@ -62,7 +62,7 @@ const KanbanColumn = ({ column, addTask, deleteTask }) => {
               </div>
               {!taskAddMode ? (
                 <button
-                  className="flex flex-row items-center gap-1 rounded-md px-1 text-left hover:bg-gray-600"
+                  className="flex flex-row items-center gap-1 rounded-md px-1 text-left dark:hover:bg-gray-600 hover:bg-gray-200"
                   onClick={() => setTaskAddMode(true)}
                 >
                   <BsPlus className="h-6 w-6" />

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -6,6 +6,7 @@ import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { FormEvent, useState } from "react";
 import { BsPlus } from "react-icons/bs";
 import { v4 } from "uuid";
+import useMediaQuery from "@Utils/hooks/useMediaQuery";
 
 const KanbanColumn = ({ column, addTask, deleteTask }) => {
   const [taskAddMode, setTaskAddMode] = useState(false);
@@ -102,8 +103,8 @@ const KanbanColumn = ({ column, addTask, deleteTask }) => {
 
 export const Kanban = ({}) => {
   const { isKanbanToggled, setIsKanbanToggled } = useToggleKanban();
-
   const { board, setColumns } = useKanban();
+  const isDesktop = useMediaQuery("(min-width: 641px)");
 
   const addTask = (columnId: string, taskName: string) => {
     const column = board.columns.filter(obj => {
@@ -152,7 +153,7 @@ export const Kanban = ({}) => {
   };
 
   return (
-    <div className="mb-2 w-72 rounded-lg border border-gray-200 bg-white/[.96] py-4 px-3 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800/[.96] dark:text-gray-300 sm:w-[40rem]">
+    <div className="my-2 w-72 rounded-lg border border-gray-200 bg-white/[.96] py-4 px-3 text-gray-800 shadow-md dark:border-gray-700 dark:bg-gray-800/[.96] dark:text-gray-300 sm:w-[40rem]">
       <div className="flex w-full flex-col">
         <div className="mb-2 flex flex-row items-center justify-between">
           <h1 className="font-bold text-gray-800 dark:text-white">Kanban board</h1>
@@ -165,7 +166,7 @@ export const Kanban = ({}) => {
         </div>
         <div className="cancelDrag flex h-full w-full flex-row items-center gap-2">
           <DragDropContext onDragEnd={onDragEnd}>
-            <div className="flex w-full flex-row gap-2">
+            <div className={`flex w-full gap-2 ${isDesktop ? "flex-row" : "flex-col"}`}>
               {board.columns.map(column => (
                 <KanbanColumn
                   key={column.id}

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -248,7 +248,7 @@ export const Kanban = ({}) => {
         </div>
         <div className="cancelDrag flex h-full w-full flex-row items-center gap-2 overflow-hidden">
           <DragDropContext onDragEnd={onDragEnd}>
-            <div className={`flex w-full gap-2 ${isDesktop ? "flex-row" : "flex-col"}`}>
+            <div className={`flex w-full h-full gap-2 ${isDesktop ? "flex-row" : "flex-col"}`}>
               {board.columns.map((column, columnIndex) => (
                 <KanbanColumn
                   key={column.id}

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -124,56 +124,61 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
       {provided => {
         return (
           <div ref={provided.innerRef} {...provided.droppableProps} className="w-1/3">
-            <div className="flex h-full w-full mb-4 flex-grow-0 flex-col gap-2 overflow-auto">
+            <div className="mb-4 flex h-full w-full flex-grow-0 flex-col gap-2 overflow-auto">
               <h2 className="font-bold">{column.title}</h2>
               <div className="flex h-full flex-col justify-between gap-2 overflow-y-auto">
-                <div className="flex flex-col gap-2 pr-1 min-h-[160px]">
-                  {column.tasks.map((task, index) => (
-                    <KanbanCard
-                      task={task}
-                      taskIndex={index}
-                      provided={provided}
-                      deleteTask={taskIndex => deleteTask(taskIndex)}
-                      updateTaskName={(taskIndex, name) => updateTaskName(taskIndex, name)}
-                    />
-                  ))}
-                  {provided.placeholder}
-                </div>
-                <div className="w-full">
-                  {!taskAddMode ? (
-                    <button
-                      className="flex w-full flex-row items-center gap-1 rounded-md px-1 text-left hover:bg-gray-200 dark:hover:bg-gray-600"
-                      onClick={() => setTaskAddMode(true)}
-                    >
-                      <BsPlus className="h-6 w-6" />
-                      <span className="align-middle">Add Task</span>
-                    </button>
-                  ) : (
-                    <form onSubmit={e => onFormSubmit(e)}>
-                      <div className="px-1">
-                        <input
-                          autoFocus
-                          value={taskInputValue}
-                          onChange={event => {
-                            setTaskInputValue(event.target.value);
-                          }}
-                          placeholder="Enter a task name..."
-                          className="mb-2 w-full overflow-hidden rounded-sm border border-gray-300 p-1 dark:border-gray-500 dark:bg-gray-700"
-                        />
-                        <div className="flex w-full flex-row gap-1">
-                          <button ref={addTaskButtonRef} className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700">
-                            Add Task
-                          </button>
-                          <button
-                            className="rounded-md px-2 py-0.5 hover:bg-gray-300 dark:hover:bg-gray-600"
-                            onClick={() => setTaskInputValue("")}
-                          >
-                            Cancel
-                          </button>
+                <div className="flex justify-between min-h-[160px] h-full flex-col gap-2 pr-1">
+                  <div className="flex flex-col gap-2">
+                    {column.tasks.map((task, index) => (
+                      <KanbanCard
+                        task={task}
+                        taskIndex={index}
+                        provided={provided}
+                        deleteTask={taskIndex => deleteTask(taskIndex)}
+                        updateTaskName={(taskIndex, name) => updateTaskName(taskIndex, name)}
+                      />
+                    ))}
+                    {provided.placeholder}
+                  </div>
+                  <div className="w-full">
+                    {!taskAddMode ? (
+                      <button
+                        className="flex w-full flex-row items-center gap-1 rounded-md px-1 text-left hover:bg-gray-200 dark:hover:bg-gray-600"
+                        onClick={() => setTaskAddMode(true)}
+                      >
+                        <BsPlus className="h-6 w-6" />
+                        <span className="align-middle">Add Task</span>
+                      </button>
+                    ) : (
+                      <form onSubmit={e => onFormSubmit(e)}>
+                        <div className="px-1">
+                          <input
+                            autoFocus
+                            value={taskInputValue}
+                            onChange={event => {
+                              setTaskInputValue(event.target.value);
+                            }}
+                            placeholder="Enter a task name..."
+                            className="mb-2 w-full overflow-hidden rounded-sm border border-gray-300 p-1 dark:border-gray-500 dark:bg-gray-700"
+                          />
+                          <div className="flex w-full flex-row gap-1">
+                            <button
+                              ref={addTaskButtonRef}
+                              className="rounded-md bg-blue-600 px-2 py-0.5 text-white hover:bg-blue-700"
+                            >
+                              Add Task
+                            </button>
+                            <button
+                              className="rounded-md px-2 py-0.5 hover:bg-gray-300 dark:hover:bg-gray-600"
+                              onClick={() => setTaskInputValue("")}
+                            >
+                              Cancel
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                    </form>
-                  )}
+                      </form>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -217,11 +217,7 @@ export const Kanban = ({}) => {
   const onDragEnd = result => {
     const { destination, source, draggableId } = result;
 
-    if (!destination) {
-      return;
-    }
-
-    if (destination.droppableId === source.droppableId && destination.index === source.index) {
+    if (!destination || (destination.droppableId === source.droppableId && destination.index === source.index)) {
       return;
     }
 

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -189,7 +189,7 @@ const KanbanColumn = ({ column, addTask, deleteTask, updateTaskName }) => {
 export const Kanban = ({}) => {
   const { setIsKanbanToggled } = useToggleKanban();
   const { board, setColumns } = useKanban();
-  const isDesktop = useMediaQuery("(min-width: 641px)");
+  const isDesktop = useMediaQuery("(min-width: 768px)");
 
   const addTask = (columnIndex: number, taskName: string) => {
     let columns = board.columns;

--- a/src/components/Kanban/Kanban.tsx
+++ b/src/components/Kanban/Kanban.tsx
@@ -106,7 +106,7 @@ const KanbanColumn = ({ column, addTask, deleteTask }) => {
 };
 
 export const Kanban = ({}) => {
-  const { isKanbanToggled, setIsKanbanToggled } = useToggleKanban();
+  const { setIsKanbanToggled } = useToggleKanban();
   const { board, setColumns } = useKanban();
   const isDesktop = useMediaQuery("(min-width: 641px)");
 
@@ -122,15 +122,19 @@ export const Kanban = ({}) => {
     setColumns(columns);
   };
 
-  const delTask = (taskIndex: number, columnId: string) => {
+  const deleteTask = (taskIndex: number, columnId: string) => {
     const column = board.columns.filter(obj => {
       return obj.id === columnId;
     })[0];
     const columnIndex = board.columns.indexOf(column);
 
     let columns = board.columns;
-    columns[columnIndex].tasks.splice(taskIndex, 1);
 
+    if (!confirm(`Are you sure you want to delete the task "${columns[columnIndex].tasks[taskIndex].name}"?`)) {
+      return;
+    }
+
+    columns[columnIndex].tasks.splice(taskIndex, 1);
     setColumns(columns);
   };
 
@@ -176,7 +180,7 @@ export const Kanban = ({}) => {
                   key={column.id}
                   column={column}
                   addTask={(columnId, taskName) => addTask(columnId, taskName)}
-                  deleteTask={passedIndex => delTask(passedIndex, column.id)}
+                  deleteTask={passedIndex => deleteTask(passedIndex, column.id)}
                 />
               ))}
             </div>

--- a/src/components/Kanban/kanban.css
+++ b/src/components/Kanban/kanban.css
@@ -1,4 +1,6 @@
-[data-rbd-draggable-id] { 
-    left: auto !important; 
-    top: auto !important;
+@media (min-width: 641px) {
+    [data-rbd-draggable-id] {
+        left: auto !important;
+        top: auto !important;
+    }
 }

--- a/src/components/Kanban/kanban.css
+++ b/src/components/Kanban/kanban.css
@@ -4,3 +4,10 @@
         top: auto !important;
     }
 }
+
+.text-no-overflow {
+    overflow-wrap: break-word;
+    white-space: normal;
+    overflow: hidden;
+    hyphens: auto;
+}

--- a/src/components/Kanban/kanban.css
+++ b/src/components/Kanban/kanban.css
@@ -1,0 +1,4 @@
+[data-rbd-draggable-id] { 
+    left: auto !important; 
+    top: auto !important;
+}

--- a/src/components/Kanban/kanban.css
+++ b/src/components/Kanban/kanban.css
@@ -4,10 +4,3 @@
         top: auto !important;
     }
 }
-
-.text-no-overflow {
-    overflow-wrap: break-word;
-    white-space: normal;
-    overflow: hidden;
-    hyphens: auto;
-}

--- a/src/components/Nav/SideNav.tsx
+++ b/src/components/Nav/SideNav.tsx
@@ -2,7 +2,7 @@ import { NavItem } from "./NavItems";
 import { IoMusicalNotesOutline } from "react-icons/io5";
 import { IoMenu } from "react-icons/io5";
 import { CgNotes } from "react-icons/cg";
-import { MdOutlineTimer, MdWbSunny, MdDarkMode, MdOutlineNoteAdd } from "react-icons/md";
+import { MdOutlineTimer, MdWbSunny, MdDarkMode, MdOutlineNoteAdd, MdOutlineViewKanban } from "react-icons/md";
 import { VscDebugRestartFrame } from "react-icons/vsc";
 import { BsArrowsFullscreen, BsFillChatLeftQuoteFill, BsTwitch } from "react-icons/bs";
 import { FaSpotify } from "react-icons/fa";
@@ -19,6 +19,7 @@ import {
   useToggleWidgetReset,
   useToggleTwitch,
   useSideNavOrderStore,
+  useToggleKanban,
 } from "@Store";
 import { useState, useEffect } from "react";
 import useSetDefault from "@App/utils/hooks/useSetDefault";
@@ -33,6 +34,7 @@ export const SideNav = () => {
   const { isFullscreen } = useFullScreenToggleStore();
   const [active, setActive] = useState(false);
   const { isMusicToggled, setIsMusicToggled } = useToggleMusic();
+  const { isKanbanToggled, setIsKanbanToggled } = useToggleKanban();
   const { isTimerToggled, setIsTimerToggled } = useToggleTimer();
   const { isTasksToggled, setIsTasksToggled } = useToggleTasks();
   const { isSpotifyToggled, setIsSpotifyToggled } = useSpotifyMusic();
@@ -43,6 +45,7 @@ export const SideNav = () => {
   const { isStickyNoteShown } = useToggleStickyNote();
   const { isTasksShown } = useToggleTasks();
   const { isMusicShown } = useToggleMusic();
+  const { isKanbanShown } = useToggleKanban();
   const { isSpotifyShown } = useSpotifyMusic();
   const { isDarkModeShown } = useDarkToggleStore();
   const { isFullscreenShown } = useFullScreenToggleStore();
@@ -179,6 +182,16 @@ export const SideNav = () => {
       toggleString: "Fullscreen Toggled",
       toggleIcon: "",
       isShown: isFullscreenShown,
+    },
+    {
+      id: "11",
+      content: <MdOutlineViewKanban className="h-6 w-6" />,
+      tooltipTitle: "Kanban",
+      isToggled: isKanbanToggled,
+      setToggled: setIsKanbanToggled,
+      toggleString: "Kanban Toggled",
+      toggleIcon: "📃",
+      isShown: isKanbanShown,
     },
   ];
 

--- a/src/components/WidgetControl/WidgetControlModal.tsx
+++ b/src/components/WidgetControl/WidgetControlModal.tsx
@@ -2,7 +2,12 @@ import { useEffect } from "react";
 import { FaSpotify } from "react-icons/fa";
 import { IoMusicalNotesOutline, IoCloseSharp } from "react-icons/io5";
 import { CgNotes } from "react-icons/cg";
-import { MdOutlineTimer, MdWbSunny, MdOutlineNoteAdd } from "react-icons/md";
+import {
+  MdOutlineTimer,
+  MdWbSunny,
+  MdOutlineNoteAdd,
+  MdOutlineViewKanban,
+} from "react-icons/md";
 import { VscDebugRestartFrame } from "react-icons/vsc";
 import { BsArrowsFullscreen, BsFillChatLeftQuoteFill, BsTwitch } from "react-icons/bs";
 import clsx from "clsx";
@@ -18,6 +23,7 @@ import {
   useFullScreenToggleStore,
   useToggleWidgetReset,
   useToggleTwitch,
+  useToggleKanban,
 } from "@Store";
 import useMediaQuery from "@Utils/hooks/useMediaQuery";
 import { toggledToastNotification } from "@Utils/toast";
@@ -33,6 +39,7 @@ export const WidgetControlModal = ({ isVisible = false, onClose }) => {
   const { isQuoteShown, setIsQuoteShown } = useToggleQuote();
   const { isWidgetResetShown, setIsWidgetResetShown } = useToggleWidgetReset();
   const { isTwitchShown, setIsTwitchShown } = useToggleTwitch();
+  const { isKanbanShown, setIsKanbanShown } = useToggleKanban();
 
   const isDesktop = useMediaQuery("(min-width: 641px)");
 
@@ -191,6 +198,25 @@ export const WidgetControlModal = ({ isVisible = false, onClose }) => {
             >
               Twitch
               <BsTwitch className="h-6 w-full" />
+            </div>
+            <div
+              onClick={() =>
+                toggledToastNotification(
+                  isKanbanShown,
+                  setIsKanbanShown,
+                  "Kanban board Widget Added",
+                  750,
+                  "📃"
+                )
+              }
+              className={clsx(
+                "grid cursor-pointer content-center justify-center gap-2 rounded md:hover:bg-gray-200 md:hover:text-gray-800 md:dark:hover:bg-violet-500",
+                isKanbanShown &&
+                  "dark:bg-violet-500 md:bg-gray-200 md:text-gray-800"
+              )}
+            >
+              Kanban board
+              <MdOutlineViewKanban className="h-6 w-full" />
             </div>
           </div>
         </div>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -125,7 +125,7 @@ export interface IKanbanBoard {
 
 export interface IKanbanBoardState {
   board: IKanbanBoard;
-  setColumns: (column: any) => void;
+  setColumns: (columns: any) => void;
 }
 
 export interface ISongTask {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,6 +112,22 @@ export interface ITaskState {
   toggleMenu: (id: number, flag: boolean) => void;
 }
 
+export interface IKanbanBoard {
+  columns: Array<{
+    id: string;
+    title: string;
+    tasks: Array<{
+      id: string;
+      name: string;
+    }>;
+  }>;
+}
+
+export interface IKanbanBoardState {
+  board: IKanbanBoard;
+  setColumns: (column: any) => void;
+}
+
 export interface ISongTask {
   id: string;
   artist: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -139,6 +139,20 @@ export interface IToggleTasks {
   setIsTasksShown: (isTasksShown: boolean) => void;
 }
 
+export interface IToggleKanban {
+  isKanbanToggled: boolean;
+  setIsKanbanToggled: (isKanbanToggled: boolean) => void;
+  isKanbanShown: boolean;
+  setIsKanbanShown: (isKanbanShown: boolean) => void;
+}
+
+export interface IPosKanban {
+  kanbanPosX: number;
+  kanbanPosY: number;
+  setKanbanPos: (X: number, Y: number) => void;
+  setKanbanPosDefault: () => void;
+}
+
 export interface IPosTask {
   taskPosX: number;
   taskPosY: number;

--- a/src/pages/Astrostation.tsx
+++ b/src/pages/Astrostation.tsx
@@ -9,11 +9,13 @@ import {
   useStickyNote,
   useToggleQuote,
   useToggleTwitch,
+  useToggleKanban,
   usePosMusic,
   usePosSpotify,
   usePosTimer,
   usePosQuote,
   usePosTwitch,
+  usePosKanban,
   useGrid,
   useSetBackground,
 } from "@Store";
@@ -34,6 +36,7 @@ import { Sticky } from "@Components/Sticky/Sticky";
 import { Quotes } from "@App/components/Quotes/Quotes";
 import useMediaQuery from "@Utils/hooks/useMediaQuery";
 import { TwitchStream } from "@Components/Twitch/TwitchStream";
+import { Kanban } from "@Components/Kanban/Kanban";
 import { UnsplashFooter } from "../components/Nav/UnsplashFooter";
 import clsx from "clsx";
 import React from "react";
@@ -48,6 +51,7 @@ export const Astrostation = React.forwardRef<HTMLDivElement>((_props, ref) => {
   const { isStickyNoteShown } = useToggleStickyNote();
   const { isQuoteToggled, isQuoteShown } = useToggleQuote();
   const { isTwitchToggled, isTwitchShown } = useToggleTwitch();
+  const { isKanbanToggled, isKanbanShown } = useToggleKanban();
 
   // Position hooks
   const { taskPosX, taskPosY, setTaskPos } = usePosTask();
@@ -57,6 +61,7 @@ export const Astrostation = React.forwardRef<HTMLDivElement>((_props, ref) => {
   const { timerPosX, timerPosY, setTimerPos } = usePosTimer();
   const { stickyNotes, setStickyNotesPos } = useStickyNote();
   const { twitchPosX, twitchPosY, setTwitchPos } = usePosTwitch();
+  const { kanbanPosX, kanbanPosY, setKanbanPos } = usePosKanban();
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const [isSettingsModalOpen, setSettingsModalOpen] = useState(false);
   const [isConfigureWidgetModalOpen, setIsConfigureWidgetModalOpen] = useState(false);
@@ -101,7 +106,7 @@ export const Astrostation = React.forwardRef<HTMLDivElement>((_props, ref) => {
       <CryptoDonationButton />
       <BottomButtons />
       {!isDesktop ? (
-        <div className="ml-8 flex flex-col items-center pt-10 pb-40">
+        <div className="ml-8 flex flex-col items-center">
           <div className={clsx(isMusicToggled ? "block" : "hidden")}>
             <Player />
           </div>
@@ -116,6 +121,9 @@ export const Astrostation = React.forwardRef<HTMLDivElement>((_props, ref) => {
           </div>
           <div className={clsx(isQuoteToggled ? "block" : "hidden")}>
             <Quotes />
+          </div>
+          <div className={clsx(isKanbanToggled ? "block" : "hidden")}>
+            <Kanban />
           </div>
         </div>
       ) : (
@@ -195,6 +203,16 @@ export const Astrostation = React.forwardRef<HTMLDivElement>((_props, ref) => {
             gridValues={grid}
           >
             <TwitchStream />
+          </DWrapper>
+          <DWrapper
+            toggleHook={isKanbanToggled && isKanbanShown}
+            defaultX={kanbanPosX}
+            defaultY={kanbanPosY}
+            setPosition={setKanbanPos}
+            isSticky={false}
+            gridValues={grid}
+          >
+            <Kanban />
           </DWrapper>
         </>
       )}

--- a/src/store.ts
+++ b/src/store.ts
@@ -476,13 +476,13 @@ export const useKanban = create<IKanbanBoardState>(
           },
         ],
       },
-      setColumns: (column: any) => {
+      setColumns: (columns: any) => {
         set(state => ({
           board: {
-            columns: column
+            columns: columns
           }
         }));
-      },
+      }
     }),
     {
       name: "state_kanban_board",

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,6 +38,8 @@ import {
   IGrid,
   ILockWidgets,
   ISideNavOrderStore,
+  IToggleKanban,
+  IPosKanban,
   ISeoContent,
   IBackgroundColor,
 } from "./interfaces";
@@ -460,6 +462,41 @@ export const useSetBackground = create<IBackground>(
     }),
     {
       name: "app_background",
+    }
+  )
+);
+
+/**
+ * Kanban Section Store
+ * ---
+ * Handle the visibility of the Kanban section
+ */
+
+export const useToggleKanban = create<IToggleKanban>(
+  persist(
+    (set, _) => ({
+      isKanbanToggled: false,
+      setIsKanbanToggled: (isKanbanToggled) => set({ isKanbanToggled }),
+      isKanbanShown: false,
+      setIsKanbanShown: (isKanbanShown) => set({ isKanbanShown }),
+    }),
+    {
+      name: "state_kanban_section",
+    }
+  )
+);
+
+export const usePosKanban = create<IPosKanban>(
+  persist(
+    (set, _) => ({
+      kanbanPosX: 200,
+      kanbanPosY: 0,
+      setKanbanPos: (X, Y) => set({ kanbanPosX: X, kanbanPosY: Y }),
+      setKanbanPosDefault: () =>
+        set(() => ({ kanbanPosX: 200, kanbanPosY: 0 })),
+    }),
+    {
+      name: "set_kanban_position",
     }
   )
 );

--- a/src/store.ts
+++ b/src/store.ts
@@ -41,9 +41,11 @@ import {
   IToggleKanban,
   IPosKanban,
   ISeoContent,
+  IKanbanBoardState,
   IBackgroundColor,
 } from "./interfaces";
 import { InfoSection } from "./pages/InfoSection";
+import { uuid } from "uuidv4";
 
 /**
  * Grid Store
@@ -248,9 +250,9 @@ export const useStickyNote = create<IStickyNoteState>(
           stickyNotes: state.stickyNotes.map(note =>
             note.id === id
               ? {
-                  ...note,
-                  [newProp]: newValue,
-                }
+                ...note,
+                [newProp]: newValue,
+              }
               : note
           ),
         }));
@@ -398,9 +400,9 @@ export const useTask = create<ITaskState>(
           tasks: state.tasks.map(task =>
             task.id === id
               ? ({
-                  ...task,
-                  menuToggled: flag,
-                } as ITask)
+                ...task,
+                menuToggled: flag,
+              } as ITask)
               : task
           ),
         }));
@@ -447,6 +449,48 @@ export const useSong = create<ISongState>(set => ({
 }));
 
 /**
+ * Task Store
+ * ---
+ * Handle the tasks created in the tasks section
+ */
+
+export const useKanban = create<IKanbanBoardState>(
+  persist(
+    (set, _) => ({
+      board: {
+        columns: [
+          {
+            id: "abac",
+            title: "To Do",
+            tasks: [{ id: "632727", name: "Need to do this important task" }],
+          },
+          {
+            id: "aawdawd",
+            title: "In Progress",
+            tasks: [{ id: "ääffw33", name: "Doing this thing" }],
+          },
+          {
+            id: "235",
+            title: "Done",
+            tasks: [{ id: "nnADAWD", name: "We done yeh" }],
+          },
+        ],
+      },
+      setColumns: (column: any) => {
+        set(state => ({
+          board: {
+            columns: column
+          }
+        }));
+      },
+    }),
+    {
+      name: "state_kanban_board",
+    }
+  )
+);
+
+/**
  * Background Store
  * ---
  * Handles the background image state of app
@@ -467,9 +511,9 @@ export const useSetBackground = create<IBackground>(
 );
 
 /**
- * Kanban Section Store
+ * Kanban board Store
  * ---
- * Handle the visibility of the Kanban section
+ * Handle the visibility of the Kanban board
  */
 
 export const useToggleKanban = create<IToggleKanban>(

--- a/src/store.ts
+++ b/src/store.ts
@@ -41,8 +41,7 @@ import {
   IToggleKanban,
   IPosKanban,
   ISeoContent,
-  IKanbanBoardState,
-  IBackgroundColor,
+  IKanbanBoardState
 } from "./interfaces";
 import { InfoSection } from "./pages/InfoSection";
 import { uuid } from "uuidv4";

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,6 +46,7 @@ import {
 } from "./interfaces";
 import { InfoSection } from "./pages/InfoSection";
 import { uuid } from "uuidv4";
+import { v4 } from "uuid";
 
 /**
  * Grid Store
@@ -460,19 +461,19 @@ export const useKanban = create<IKanbanBoardState>(
       board: {
         columns: [
           {
-            id: "abac",
+            id: v4(),
             title: "To Do",
-            tasks: [{ id: "632727", name: "Need to do this important task" }],
+            tasks: [{ id: v4(), name: "Some important task" }],
           },
           {
-            id: "aawdawd",
+            id: v4(),
             title: "In Progress",
-            tasks: [{ id: "ääffw33", name: "Doing this thing" }],
+            tasks: [{ id: v4(), name: "A thing in progress" }],
           },
           {
-            id: "235",
+            id: v4(),
             title: "Done",
-            tasks: [{ id: "nnADAWD", name: "We done yeh" }],
+            tasks: [{ id: v4(), name: "It's done!" }],
           },
         ],
       },


### PR DESCRIPTION
![preview](https://user-images.githubusercontent.com/57040351/230682338-fdb1fde4-3994-4ffe-bc65-4ec95fa440ef.png)

Implements the Kanban board widget as discussed and seen in #266 

**Currently known issues:**
- Drag and drop is a bit weird/offset, fix unknown (seems to be because of the draggable container)
- Widget can be dragged outside of the grid's bounds which causes overflow (this issue is caused by the fixed size of draggable widget containers, will be fixed with the PR by @royanger)

**Current Todos**
- [x] Remove extra CSS and use Tailwind --> mostly done, not sure if custom rbd selector can be queried with tailwind
- [x] Remove column border to have more space for cards/prevent cards being squished
- [x] Make widget resizable
- [x] Fix task add bug introduced after rewrite
- [x] Auto scroll to show cancel and add buttons when adding a new task
- [x] Implement card/task editing
- [x] Add myself to contributors.yml
- [ ] Check if removal of IBackgroundColor in store.tsx causes any issues (seems to be a dead import or renamed? hopefully not something that broke while rebasing) 
- [ ] Maybe improve resizing and handling of the minimum height?

Potential future Todos:
- Custom scrollbars on column overflow
- Card descriptions
- Card colors
- Draggable columns
- Ability to add, remove and rename columns
All of these could be added down the line but would need some extra work like a Modal to pop up when clicking on cards to present all of these options.

**Questions for review:**
- Is the way I mutate state fine, or should the addTask and deleteTask functions be removed with appropriate equivalents directly inside the state?
- Anything else that would need to be changed in the implementation?