### PR TITLE
fix: task tracker causes overflow #244

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -13,3 +13,4 @@
 - Samathingamajig
 - cosmiclasagnadev
 - trobonox
+- zemzelett

--- a/src/components/TaskTracker/TaskTracker.tsx
+++ b/src/components/TaskTracker/TaskTracker.tsx
@@ -13,7 +13,7 @@ export const TaskTracker = () => {
   const [isTaskInfoModalOpen, setIsTaskInfoModalOpen] = useState(false);
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white/[.96] shadow-md dark:border-gray-700 dark:bg-gray-800/[.96]">
+    <div className="mb-2 w-72 sm:w-96 rounded-lg border border-gray-200 bg-white/[.96] shadow-md dark:border-gray-700 dark:bg-gray-800/[.96]">
       <div className="handle flex w-full cursor-move justify-between p-2">
         <TaskInfoModal isVisible={isTaskInfoModalOpen} onClose={() => setIsTaskInfoModalOpen(false)} />
         <IoInformationCircleOutline
@@ -25,7 +25,7 @@ export const TaskTracker = () => {
           onClick={() => setIsTasksToggled(false)}
         />
       </div>
-      <div className="joyRideTaskTracker mb-2 w-72 pb-3 pr-3 pl-3 dark:text-gray-300 sm:w-96 ">
+      <div className="joyRideTaskTracker pb-3 pr-3 pl-3 dark:text-gray-300">
         <Header title="Task Tracker" onAdd={() => setShowAddTask(!showAddTask)} showAdd={showAddTask} />
         {showAddTask && <AddTask />}
         {tasks.length > 0 ? <Tasks tasks={tasks} /> : "No Tasks to Show"}


### PR DESCRIPTION
This PR fixes #244 

While trying to figure out what was causing the bug (The inner element `div > .joyRideTaskTracker` of the task tracker `dcard` is 2 pixels wider than it should be) i noticed that a certain portion of the Tailwind classes, that are generally set on the outermost wrapper, were set on `div > .joyRideTaskTracker` instead. Streamlining that fixed the observed behavior.