### PR TITLE
bugfix: icon not showing in the firefox browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="msapplication-TileImage" content="/favicon-144x144.png" />
-    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-144x144.png" />
-    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="icon" type="image/png" sizes="144x144" href="/assets/images/index/favicon144x144.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/assets/images/index/favicon-96x96.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/index/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/index/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="canonical" href="https://www.astrostation.me" />
     <meta name="theme-color" content="#ffffff" />


### PR DESCRIPTION
hi guys. i am not able to see the website icon on firefox browser tab. i use this site a lot, kudos great simple easy to use product. it annoys me a little bit as i pin my websites in my browser when i dont see the icon lol.

The issue i found was the reference of the image icons was wrong. i have checked by deploying locally. it is working alright. let me know if we can merge this change and deploy hopefully. 

please feel free to review the changes if you find something wrong. thanks and regards.

